### PR TITLE
Add support for Azure Cosmos DB as a sink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
     </properties>
     <dependencies>
         <dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-core-http-netty</artifactId>
+    <version>1.14.2</version>
+</dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.17.1</version>
@@ -53,7 +58,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.8</version>
+            <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -133,7 +138,20 @@
             <artifactId>iot-device-client</artifactId>
             <version>1.3.30</version>
         </dependency>
-        
+        <!-- Microsoft -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-sdk-bom</artifactId>
+            <version>1.2.23</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <artifactId>azure-cosmos</artifactId>
+            <groupId>com.azure</groupId>
+            <version>4.59.0</version>
+        </dependency>
+
         <!-- AWS -->
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -149,7 +167,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.7</version>
+            <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pulsar</groupId>

--- a/src/main/java/net/acesinc/data/json/generator/JsonDataGenerator.java
+++ b/src/main/java/net/acesinc/data/json/generator/JsonDataGenerator.java
@@ -109,6 +109,12 @@ public class JsonDataGenerator {
                         }
                         break;
                     }
+                    // add a case for ComsoDB
+                    case "cosmosdb": {
+                        log.info("Adding CosmosDB Logger with properties: " + elProps);
+                        loggers.add(new CosmosDBLogger(elProps));
+                        break;
+                    }
                 }
             }
             if (loggers.isEmpty()) {

--- a/src/main/java/net/acesinc/data/json/generator/log/CosmosDBLogger.java
+++ b/src/main/java/net/acesinc/data/json/generator/log/CosmosDBLogger.java
@@ -39,7 +39,7 @@ public class CosmosDBLogger implements EventLogger {
     public void logEvent(String event, Map<String, Object> producerConfig) {
         try {
             JsonNode jsonNode = mapper.readTree(event);
-            CosmosItemResponse<Object> item = cosmosContainer.createItem(jsonNode);
+            CosmosItemResponse<JsonNode> item = cosmosContainer.createItem(jsonNode);
             log.info("Document added to Cosmos DB with request charge of " + item.getRequestCharge() + " within session " + item.getSessionToken());
         } catch (Exception e) {
             log.error("Error inserting JSON data into Cosmos DB", e);

--- a/src/main/java/net/acesinc/data/json/generator/log/CosmosDBLogger.java
+++ b/src/main/java/net/acesinc/data/json/generator/log/CosmosDBLogger.java
@@ -1,0 +1,56 @@
+package net.acesinc.data.json.generator.log;
+
+import com.azure.cosmos.CosmosClient;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.CosmosItemRequestOptions;
+import com.azure.cosmos.models.CosmosItemResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class CosmosDBLogger implements EventLogger {
+
+    private static final Logger log = LogManager.getLogger(CosmosDBLogger.class);
+    private CosmosClient cosmosClient;
+    private CosmosDatabase cosmosDatabase;
+    private CosmosContainer cosmosContainer;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public CosmosDBLogger(Map<String, Object> props) {
+        String uri = (String) props.get("uri");
+        String key = (String) props.get("key");
+        String databaseName = (String) props.get("databaseName");
+        String containerName = (String) props.get("containerName");
+
+        cosmosClient = new CosmosClientBuilder()
+                .endpoint(uri)
+                .key(key)
+                .buildClient();
+
+        cosmosDatabase = cosmosClient.getDatabase(databaseName);
+        cosmosContainer = cosmosDatabase.getContainer(containerName);
+    }
+
+    @Override
+    public void logEvent(String event, Map<String, Object> producerConfig) {
+        try {
+            JsonNode jsonNode = mapper.readTree(event);
+            CosmosItemResponse<Object> item = cosmosContainer.createItem(jsonNode);
+            log.info("Document added to Cosmos DB with request charge of " + item.getRequestCharge() + " within session " + item.getSessionToken());
+        } catch (Exception e) {
+            log.error("Error inserting JSON data into Cosmos DB", e);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        if (cosmosClient != null) {
+            cosmosClient.close();
+            log.info("Cosmos DB client closed successfully");
+        }
+    }
+}


### PR DESCRIPTION
GitHub Copilot Workspace generated code.
---
Related to #1

Adds support for Azure Cosmos DB as a sink in the JSON data generator.

- **Implements the `EventLogger` interface** in the newly added `CosmosDBLogger.java` to enable logging events directly into Azure Cosmos DB.
- **Configures Cosmos DB connection** by defining properties such as URI, key, database name, and container name within the `CosmosDBLogger` constructor, facilitating the connection setup to Cosmos DB.
- **Inserts JSON data into Cosmos DB** through the `logEvent` method, which converts the event string into a JSON node and creates an item in the Cosmos DB container.
- **Handles shutdown of Cosmos DB client** gracefully by implementing the `shutdown` method, ensuring the Cosmos DB client is properly closed.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sjwaight/json-data-generator/issues/1?shareId=7923c6a6-f3dc-4a8f-a6e9-7b9d131ce199).